### PR TITLE
adapting buildUAVSARhdr.py 

### DIFF
--- a/python/buildUAVSARhdr.py
+++ b/python/buildUAVSARhdr.py
@@ -120,7 +120,7 @@ def main():
         os._exit(1)
 
 
-    genHDRfromTXT(args)
+    genHDRfromTXT(args.input, args.uavsar, args.polarization)
 
 
 if __name__ == "__main__":

--- a/python/buildUAVSARhdr.py
+++ b/python/buildUAVSARhdr.py
@@ -47,9 +47,13 @@ def genHDRfromTXT(annFile, dataFile, pol):
                 print('Lines =', GRDLines)
                 headerPar['GRDLines'] = GRDLines
             elif 'grd_pwr.row_mult' in line:
-                GRDPixel = abs(float(line.split()[3].split(';')[0]))
-                print('PIXEL SIZE = ', GRDPixel)
-                headerPar['GRDPixel'] = GRDPixel
+                GRDYPixel = abs(float(line.split()[3].split(';')[0]))
+                print('PIXEL SIZE = ', GRDYPixel)
+                headerPar['GRDYPixel'] = GRDYPixel
+            elif 'grd_pwr.col_mult' in line:
+                GRDXPixel = abs(float(line.split()[3].split(';')[0]))
+                print('PIXEL SIZE = ', GRDXPixel)
+                headerPar['GRDXPixel'] = GRDXPixel
     
     # ASSIGN NUMER OF LINES AND SAMPLES BASED UPON FILE TYPE
     #print('Reading lines...')
@@ -85,7 +89,7 @@ data type = {dataType}
 interleave = bsq
 sensor type = Unknown
 byte order = 0
-map info = {{Geographic Lat/Lon, 1.5, 1.5, {ULlongCord}, {ULlatCord}, {GRDPixel}, {GRDPixel}, WGS-84, units=Degrees}}
+map info = {{Geographic Lat/Lon, 1.5, 1.5, {ULlongCord}, {ULlatCord}, {GRDXPixel}, {GRDYPixel}, WGS-84, units=Degrees}}
 coordinate system string = {{GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]]}}
 wavelength units = Unknown'''.format(**headerPar)
     enviHDRFile.write(enviHDR)
@@ -103,7 +107,9 @@ def main():
     parser.add_argument("-r", "--uavsar", type=str, help="Specify the input UAVSAR radar file")
     parser.add_argument("-p", "--polarization", type=str, help="Specify the input UAVSAR polarization in UPPERCASE (i.e HHHV)")
     args = parser.parse_args()
-
+    print(args.input)
+    print(args.uavsar)
+    print(args.polarization)
     if '.txt' in str(args.input):
         pass
     else:
@@ -119,7 +125,7 @@ def main():
         print("SPECIFY UAVSAR IMAGE POLARIZATION (i.e. 'HHHV')")
         os._exit(1)
 
-
+    print(args)
     genHDRfromTXT(args.input, args.uavsar, args.polarization)
 
 

--- a/python/buildUAVSARhdr.py
+++ b/python/buildUAVSARhdr.py
@@ -107,9 +107,7 @@ def main():
     parser.add_argument("-r", "--uavsar", type=str, help="Specify the input UAVSAR radar file")
     parser.add_argument("-p", "--polarization", type=str, help="Specify the input UAVSAR polarization in UPPERCASE (i.e HHHV)")
     args = parser.parse_args()
-    print(args.input)
-    print(args.uavsar)
-    print(args.polarization)
+
     if '.txt' in str(args.input):
         pass
     else:
@@ -125,7 +123,6 @@ def main():
         print("SPECIFY UAVSAR IMAGE POLARIZATION (i.e. 'HHHV')")
         os._exit(1)
 
-    print(args)
     genHDRfromTXT(args.input, args.uavsar, args.polarization)
 
 


### PR DESCRIPTION
buildUAVSARhdr.py assumes that the GRD pixel spacing is the same in x and y direction. But some UAVSAR locations have different values for x and y. Thus, this can result in a geocoding error.